### PR TITLE
cross platform oddities with resty + removed parsing of thread

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f
 	github.com/go-resty/resty/v2 v2.7.0
-	github.com/jarcoal/httpmock v1.2.0
+	github.com/jarcoal/httpmock v1.3.0
 	github.com/panjf2000/ants/v2 v2.5.0
 	github.com/spf13/cobra v1.4.0
 	github.com/valyala/fastjson v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,10 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlou685kk=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/panjf2000/ants/v2 v2.5.0 h1:1rWGWSnxCsQBga+nQbA4/iY6VMeNoOIAM0ZWh9u3q2Q=
 github.com/panjf2000/ants/v2 v2.5.0/go.mod h1:cU93usDlihJZ5CfRGNDYsiBYvoilLvBF5Qp/BT2GNRE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/link/linkhandler.go
+++ b/link/linkhandler.go
@@ -24,7 +24,6 @@ import (
 )
 
 type Parts struct {
-	Thread      string
 	PackageCode string
 	KeyCode     string
 }
@@ -44,14 +43,6 @@ type PackageCodeIsMissingErr struct {
 
 func (p PackageCodeIsMissingErr) Error() string {
 	return fmt.Sprintf("expected to have packageCode in url '%v' but it is not present", p.InputURL)
-}
-
-type ThreadIsMissingErr struct {
-	InputURL string
-}
-
-func (p ThreadIsMissingErr) Error() string {
-	return fmt.Sprintf("expected to have thread in url '%v' but it is not present", p.InputURL)
 }
 
 type QIsMissingErr struct {
@@ -115,9 +106,6 @@ func ParseLink(inputURL string) (Parts, error) {
 	if !query.Has("packageCode") {
 		return Parts{}, PackageCodeIsMissingErr{InputURL: inputURL}
 	}
-	if !query.Has("thread") {
-		return Parts{}, ThreadIsMissingErr{InputURL: inputURL}
-	}
 	// for whatever reason keyCode is stored as a fragment, this is a bit tricker but we know what it starts with
 	// however, this is the most fragile part and if the URL scheme varies a bit this will break badly
 	keyCodeRaw := u.Fragment
@@ -129,7 +117,6 @@ func ParseLink(inputURL string) (Parts, error) {
 	}
 
 	return Parts{
-		Thread:      query.Get("thread"),
 		PackageCode: query.Get("packageCode"),
 		KeyCode:     keyCodeRaw[8:], //throwing away keyCode= and only keeping the rest of the string
 	}, nil

--- a/link/linkhandler_test.go
+++ b/link/linkhandler_test.go
@@ -49,11 +49,6 @@ func TestLinkHandlerWithEncodedByGoogleUrlAfterPastedInTerminal(t *testing.T) {
 	if linkParts.PackageCode != expectedPackageCode {
 		t.Errorf("expected package code '%v' but got '%v'", expectedPackageCode, linkParts.PackageCode)
 	}
-
-	expectedThread := "MYTHREAD"
-	if linkParts.Thread != expectedThread {
-		t.Errorf("expected thread '%v' but got '%v'", expectedThread, linkParts.Thread)
-	}
 }
 func TestLinkHandlerWithEncodedByGoogleUrl(t *testing.T) {
 	url := "https://www.google.com/url?q=https%3A%2F%2Fsendsafely.tester.com%2Freceive%2F%3Fthread%3DMYTHREAD%26packageCode%3DMYPKGCODE%23keyCode%3DMYKEYCODE&sa=D&ust=11111111&usg=JJJJJJJJJ"
@@ -71,10 +66,6 @@ func TestLinkHandlerWithEncodedByGoogleUrl(t *testing.T) {
 		t.Errorf("expected package code '%v' but got '%v'", expectedPackageCode, linkParts.PackageCode)
 	}
 
-	expectedThread := "MYTHREAD"
-	if linkParts.Thread != expectedThread {
-		t.Errorf("expected thread '%v' but got '%v'", expectedThread, linkParts.Thread)
-	}
 }
 
 func TestLinkHandler(t *testing.T) {
@@ -93,10 +84,6 @@ func TestLinkHandler(t *testing.T) {
 		t.Errorf("expected package code '%v' but got '%v'", expectedPackageCode, linkParts.PackageCode)
 	}
 
-	expectedThread := "MYTHREAD"
-	if linkParts.Thread != expectedThread {
-		t.Errorf("expected thread '%v' but got '%v'", expectedThread, linkParts.Thread)
-	}
 }
 
 func TestKeyCodeMissing(t *testing.T) {
@@ -136,23 +123,6 @@ func TestPackageCodeMissing(t *testing.T) {
 	}
 }
 
-func TestThreadMissing(t *testing.T) {
-	url := "https://sendsafely.tester.com/receive/?packageCode=MYPKGCODE#keyCode=MYKEYCODE"
-	_, err := ParseLink(url)
-	if err == nil {
-		t.Fatalf("exected error '%v'", err)
-	}
-	if !errors.Is(err, ThreadIsMissingErr{
-		InputURL: url,
-	}) {
-		t.Errorf("expected ThreadIsMissingErr but got %v", err)
-	} else {
-		expectedError := "expected to have thread in url 'https://sendsafely.tester.com/receive/?packageCode=MYPKGCODE#keyCode=MYKEYCODE' but it is not present"
-		if err.Error() != expectedError {
-			t.Errorf("expected error text of '%v' but was '%v'", expectedError, err.Error())
-		}
-	}
-}
 
 func TestInvalidUrlForGoogleURL(t *testing.T) {
 	url := "https://www.google.com/url*$ù%?q=https%3A%2F%2Fsendsafely.tester.com%2Freceive%2F%3Fthread%3DMYTHREAD%26packageCode%3DMYPKGCODE%23keyCode%3DMYKEYCODE&sa=D&ust=11111111&usg=JJJJJJJJJ"

--- a/zendesk/api.go
+++ b/zendesk/api.go
@@ -14,13 +14,14 @@
    limitations under the License.
 */
 
-//zendesk package provides api access to the zendesk rest api
+// zendesk package provides api access to the zendesk rest api
 package zendesk
 
 import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 
@@ -89,6 +90,10 @@ func (z *Client) GetTicketComentsJSON(ticketID string, pageURL *string) (string,
 		return "", fmt.Errorf("unable to read ticket comments with error '%v'", err)
 	}
 	rawBody := r.Body()
+    statusCode := r.StatusCode() 
+	if statusCode > 299 {
+		return "", errors.New(string(rawBody))
+    }
 	if z.verbose {
 		var prettyJSONBuffer bytes.Buffer
 		if err := json.Indent(&prettyJSONBuffer, rawBody, "=", "\t"); err != nil {


### PR DESCRIPTION
we had a couple of oddities here

* we should not be parsing thread because we don't use it and it is not always present * resty is a dead project it seems and it has a cross platform oddity where status code > 299 does not throw an 
error, but on some it does. Working around this by checking for status code and returning an error.
